### PR TITLE
give vmware permissions to create log

### DIFF
--- a/tasks/chaperone-ui.yml
+++ b/tasks/chaperone-ui.yml
@@ -84,7 +84,7 @@
   tags:
     - rsync
     - rsync_ansible_only
-    
+
 - name: recursively sync the ansible library from local repos
   become: no
   synchronize:
@@ -99,7 +99,7 @@
   tags:
     - rsync
     - rsync_ansible_only
-    
+
 - name: create application directory
   file:
     dest: "/opt/containers"
@@ -200,6 +200,16 @@
     owner: "{{ ansible_ssh_user }}"
     group: "{{ ansible_ssh_user }}"
     mode: 0755
+  tags:
+    - rsync
+
+- name: Create Logs directory
+  file:
+    dest: "{{ chaperone_log_dir }}"
+    state: directory
+    owner: "root"
+    group: "{{ ansible_ssh_user }}"
+    mode: 0775
   tags:
     - rsync
 


### PR DESCRIPTION
bad permissions on the chaperone log dir prevents db init from working. 